### PR TITLE
fix(nestjs-redox): update CSP header to allow Redoc bundle via script-src-elem

### DIFF
--- a/libs/nestjs-redox/src/lib/nestjs-redox.module.ts
+++ b/libs/nestjs-redox/src/lib/nestjs-redox.module.ts
@@ -324,8 +324,8 @@ export class NestjsRedoxModule {
   }
 
   /**
-   * fixes content security policy issue
-   * see issue #1 and #17
+   * Fixes content security policy issue
+   * see issue #2 and #17
    * @param httpAdapter
    * @param res
    * @private

--- a/libs/nestjs-redox/src/lib/nestjs-redox.module.ts
+++ b/libs/nestjs-redox/src/lib/nestjs-redox.module.ts
@@ -324,7 +324,8 @@ export class NestjsRedoxModule {
   }
 
   /**
-   * fixes content security policy issue see issue #1
+   * fixes content security policy issue
+   * see issue #1 and #17
    * @param httpAdapter
    * @param res
    * @private
@@ -332,7 +333,7 @@ export class NestjsRedoxModule {
   private static setContentSecurityHeader(httpAdapter: HttpServer, res: Response, nonce: string) {
     const header = {
       name: 'Content-Security-Policy',
-      value: `script-src 'self' 'nonce-${nonce}'; child-src 'self' 'nonce-${nonce}' blob:;`,
+      value: `script-src 'self' 'nonce-${nonce}'; script-src-elem 'self' 'nonce-${nonce}' https://cdn.redoc.ly; child-src 'self' 'nonce-${nonce}' blob:;`,
     };
 
     if (httpAdapter.getType() === 'express') {


### PR DESCRIPTION
Fixes #17 

Added `script-src-elem` directive to Content-Security-Policy header to allow loading Redoc bundle from https://cdn.redoc.ly.

This resolves the issue where the external script was blocked by CSP due to missing configuration for script-src-elem, when standalone is false.